### PR TITLE
updated travis env to node 8 and Ubuntu trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
+sudo: false
+dist: trusty
 node_js:
-  - 'stable'
+  - '8'


### PR DESCRIPTION
Travis has been running their builds on a super old version of Ubuntu, `Precise` (which no longer has LTS support and is at `12.04.5`). At this point, most folks (myself included) use `Xenial` (currently `16.04.3`), but they've made it clear they're not going to add it; in the meantime, they've been working on a large transition towards `Trusty` (currently `14.04.5` and still an active LTS). While previously `sudo` was presumed false, when specifying the `dist` as `Trusty` (i.e. `dist: trusty`) you have to explicitly declare it.

Also, w/r/t the node version, `nvm` has now deprecated `stable` and IMO just putting the major version numbers aligns just fine with getting the most recent version for every test run; hence `8`.