### PR TITLE
Fix example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,11 +60,7 @@ generate()
   "typeScale": [
     3, 2.25, 1.5, 1.25, 1, 0.875
   ],
-  "spacing": {
-    "root": 8,
-    "ratio": 2,
-    "steps": 6
-  },
+  "spacing": [2, 4, 6, 8, 10, 12, 14],
   "customMedia": [
     { "m": 48 },
     { "l": 64 },


### PR DESCRIPTION
The example in the README is wrong and generate an invalid CSS.

This PR fixes the example and uses the same spacing used in the `config.js` file.