### PR TITLE
Fix minify property on buildCss call

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = config => {
 
     const post = await assembleCss(modules, _config)
 
-    const min = await buildCss(post, { minified: true })
+    const min = await buildCss(post, { minify: true })
     const css = await buildCss(post)
 
     const docs = generateDocs(_config, { modules, min: min.css })

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "partials"
   ],
   "scripts": {
-    "test": "ava -v --timeout=10s",
+    "test": "ava -v --timeout=20s",
     "docs": "node docs > out.html && open out.html"
   },
   "repository": "tachyons-css/tachyons-generator",

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ const generate = async () => {
   
   fs.writeFileSync('index.html', out.docs)
   fs.writeFileSync('tachyons.css', out.css)
+  fs.writeFileSync('tachyons.min.css', out.min)
 }
 
 generate()


### PR DESCRIPTION
The correct option name as used by `tachyons-build-css` is `minify`, not `minified`. Current tachyons-generator generates `min === css`. 

https://github.com/tachyons-css/tachyons-build-css/blob/61144d4144d45a75388728be4141fdcf0141316c/index.js#L30

